### PR TITLE
 nixos/godns: allow multiple godns instances

### DIFF
--- a/nixos/tests/godns.nix
+++ b/nixos/tests/godns.nix
@@ -8,9 +8,37 @@ with lib;
 
   nodes.machine =
     { pkgs, ... }:
-    { services.godns.enable = true; };
+    {
+      services.godns.instances.instance1 = {
+        settings = {
+          provider = "Cloudflare";
+          login_token = "API Token";
+          domains = [
+            {
+              domain_name = "example.com";
+              sub_domains = [ "www" "test" ];
+            }
+          ];
+          ip_type = "IPv4";
+        };
+      };
+      services.godns.instances.instance2 = {
+        settings = {
+          provider = "Cloudflare";
+          login_token = "API Token";
+          domains = [
+            {
+              domain_name = "example.com";
+              sub_domains = [ "www" "test" ];
+            }
+          ];
+          ip_type = "IPv6";
+        };
+      };
+    };
 
   testScript = ''
-    machine.wait_for_unit("godns.service")
+    machine.wait_for_unit("godns-instance1.service")
+    machine.wait_for_unit("godns-instance2.service")
   '';
 })


### PR DESCRIPTION
The first commit adds the support of multiple godns instances.
The second commit provides secret passing mechanisms and switches to systemd dynamic user.

## Explanation of the second commit

At first, I don't understand why there still be a `dataDir`. The tmpfiles rule let me understand that the `dataDir` is used for holding secrets.

I think we should use the systemd option `EnvironmentFile` or `LoadCredential` to pass secrets securely and reliably instead of creating a `dataDir` privately owned by the user `godns`. To archive this, I add corresponding the options `environmentFile` and `loadCredential`, and add `envsubst` to substitute environment variables in setting files.

Then the user `godns` is no longer needed. We can use the systemd `DynamicUser` feature instead.

## Example and test

I tested the module on my configurations like this and it works well. (I'm using [sops-nix](https://github.com/Mic92/sops-nix) for secret provisioning, so this example uses sops-nix and LoadCredential.)

```nix
{
  services.godns.instances = {
    ipv4 = {
      loadCredential = [ "login_token_file:${config.sops.secrets."cloudflare-token".path}" ];
      settings = {
        provider = "Cloudflare";
        login_token_file = "$CREDENTIALS_DIRECTORY/login_token_file";
        domains = [{
          domain_name = "example.com";
          sub_domains = [ "test" ];
        }];
        ip_type = "IPv4";
        ip_url = "";
        ip_interface = "enp4s0";
      };
    };
    ipv6 = {
      loadCredential = [ "login_token_file:${config.sops.secrets."cloudflare-token".path}" ];
      settings = {
        provider = "Cloudflare";
        login_token_file = "$CREDENTIALS_DIRECTORY/login_token_file";
        domains = [{
          domain_name = "example.com";
          sub_domains = [ "test" ];
        }];
        ip_type = "IPv6";
      };
    };
  };
  sops.secrets."cloudflare-token".sopsFile = ./path/to/my-secrets.yaml;
}
```